### PR TITLE
fix(dictionary): Use local JSON file for word lookup

### DIFF
--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -1,4 +1,4 @@
-import { performSpellCheck } from '../src/app/actions';
+import { performSpellCheck, getWordDetails } from '../src/app/actions';
 import { JSDOM } from 'jsdom';
 
 // Mock FormData
@@ -21,5 +21,38 @@ describe('performSpellCheck', () => {
     formData.append('text', 'আমি,ভাত');
     const result = await performSpellCheck({}, formData);
     expect(result.suggestions).toEqual([]);
+  });
+});
+
+describe('getWordDetails', () => {
+  it('should return details for an existing word', async () => {
+    const result = await getWordDetails('carry-on');
+    // Ensure no error is returned
+    expect(result.error).toBeUndefined();
+
+    // Check if the word property exists and is correct
+    if ('word' in result) {
+      expect(result.word).toBe('carry-on');
+      expect(result.pronunciation).toBe('Bahana ana');
+      expect(result.meaning).toBe('বহন অন');
+      expect(result.synonyms).toEqual([]);
+      expect(result.examples).toEqual([
+        "And it can be attached to purses, laptops, <b>carry-ons</b> , and suitcases.",
+        "Though the no-bags option is an appealing one, I think I'll stick to <b>carry-on</b> luggage."
+      ]);
+    } else {
+      // Fail the test if word property is not in the result
+      fail('Word details not found for "carry-on"');
+    }
+  });
+
+  it('should return an error for a non-existent word', async () => {
+    const result = await getWordDetails('nonexistentword');
+    expect(result.error).toBe('"nonexistentword" শব্দটি অভিধানে পাওয়া যায়নি।');
+  });
+
+  it('should return an error for an empty input', async () => {
+    const result = await getWordDetails('');
+    expect(result.error).toBe('অনুগ্রহ করে একটি শব্দ লিখুন।');
   });
 });


### PR DESCRIPTION
The dictionary feature was failing because it was attempting to fetch word definitions from a Firestore database that was not populated. This resulted in a "Problem fetching data from the database" error for users.

This commit refactors the `getWordDetails` function to source its data from the local `dictionary-full.json` file, as implied by the project structure and user feedback.

The key changes include:
- Removing the Firebase Firestore implementation for word lookups.
- Implementing a new data fetching mechanism that reads and parses `dictionary-full.json`.
- Caching the dictionary data in memory to avoid repeated file reads on subsequent lookups.
- Adding comprehensive unit tests for the new `getWordDetails` function to verify its correctness, including cases for found words, not-found words, and empty inputs.
- Ensuring the pronunciation and meaning fields are correctly extracted and mapped to the frontend.

This change resolves the user-reported bug and makes the dictionary feature functional and more performant by using a local data source.