### PR TITLE
Fix: Resolve build failures and production data loading errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-
         "copy-webpack-plugin": "^13.0.1",
-
         "cross-env": "^10.0.0",
         "genkit-cli": "^1.14.1",
         "jest": "^30.1.3",

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -34,7 +34,10 @@ async function getDictionaryData(): Promise<DictionaryEntry[]> {
     return dictionaryData;
   }
   try {
-    const filePath = path.join(process.cwd(), 'data', 'dictionary-full.json');
+    const dataDir = process.env.NODE_ENV === 'production'
+      ? path.join(process.cwd(), '.next/server/data')
+      : path.join(process.cwd(), 'data');
+    const filePath = path.join(dataDir, 'dictionary-full.json');
     const fileContent = await fs.promises.readFile(filePath, 'utf-8');
     dictionaryData = JSON.parse(fileContent);
     return dictionaryData!;
@@ -114,7 +117,10 @@ const spellCheckSchema = z.object({
 
 async function getWordList() {
     try {
-        const filePath = path.join(process.cwd(), 'data', 'word-list.txt');
+        const dataDir = process.env.NODE_ENV === 'production'
+          ? path.join(process.cwd(), '.next/server/data')
+          : path.join(process.cwd(), 'data');
+        const filePath = path.join(dataDir, 'word-list.txt');
         const fileContent = await fs.promises.readFile(filePath, 'utf-8');
         const words = fileContent.split('\n').map(w => w.trim().toLowerCase());
         return new Set(words);


### PR DESCRIPTION
This commit addresses two critical issues:
1. Local build failure: The `npm run build` command was failing with a "Cannot find module 'copy-webpack-plugin'" error. This was caused by an incomplete `node_modules` directory and was resolved by running `npm install`.

2. Production dictionary error: The application was failing to load dictionary data on Vercel because the file paths in `src/app/actions.ts` were hardcoded for a development environment.

The solution involves:
- Modifying `getDictionaryData` and `getWordList` functions in `src/app/actions.ts` to dynamically determine the correct data directory based on the `NODE_ENV`.
- In production, it now correctly points to `.next/server/data`, where the files are placed by the `copy-webpack-plugin` configured in `next.config.ts`.
- In development, it continues to use the root `data` directory.

This ensures that the application can locate the dictionary and word list files in both local development and Vercel production environments, resolving the runtime errors.